### PR TITLE
Fixing broken link

### DIFF
--- a/modules/ROOT/pages/traversal-framework/traversal_framework_example.adoc
+++ b/modules/ROOT/pages/traversal-framework/traversal_framework_example.adoc
@@ -120,8 +120,7 @@ This will give the following output:
 (0)-[KNOWS,0]->(2)<-[KNOWS,2]-(3)<-[KNOWS,3]-(4)<-[KNOWS,4]-(1)
 ----
 
-To see other useful evaluators, see xref:traversal-framework/traversal-framework-java-api.adoc#traversal-java-api-evaluator[Using Evaluators].
-// For details of the interface, see the  xref:/docs/java-reference/{neo4j-version}/traversal-framework/traversal-framework-java-api/#traversal-java-api-evaluator[`org.neo4j.graphdb.traversal.Evaluator`^] javadocs.
+To see other useful evaluators, see xref:traversal-framework/traversal_framework_java_api.adoc#traversal-java-api-evaluator[Using Evaluators].
 
 The `Traverser` also has a `nodes()` method that will return an `Iterable` of all the nodes in the paths:
 


### PR DESCRIPTION
Previous PR https://github.com/neo4j/docs-java-reference/pull/61 was supposed to comment out a part of the documentation, but the content was the same. The only thing is that the link wasn't working, so here's the fix.