### PR TITLE
Adding information about the version of junit used in the example (#103)

### DIFF
--- a/modules/ROOT/pages/extending-neo4j/procedures.adoc
+++ b/modules/ROOT/pages/extending-neo4j/procedures.adoc
@@ -51,7 +51,7 @@ The test dependencies include _Neo4j Harness_ and _JUnit_.
 These can be used to write integration tests for procedures.
 The tests should start a Neo4j instance, load the procedure, and execute queries against it.
 
-.An example for testing a procedure that returns relationship types found in the graph.
+.An example using JUnit 5 for testing a procedure that returns relationship types found in the graph.
 [source, java]
 ----
 package example;
@@ -126,6 +126,11 @@ public class GetRelationshipTypesTests {
 }
 ----
 
+[NOTE]
+====
+The previous example uses JUnit 5, which requires the use of `org.neo4j.harness.junit.extension.Neo4jExtension`.
+If you want to use JUnit 4 with Neo4j 4.x or 5, use `org.neo4j.harness.junit.rule.Neo4jRule` instead.
+====
 
 == Define a procedure
 


### PR DESCRIPTION
* adding information about the version of junit used in the example and note with instructions for users who want to keep using a previous version

* update after review

* removing incorrect extra lines

* adding the information that this can also be applied to neo4j 5 instead of just 4

* Update modules/ROOT/pages/extending-neo4j/procedures.adoc

Cherry-picked from https://github.com/neo4j/docs-java-reference/pull/103

---------