### PR TITLE
Adding information about the version of junit used in the example (#103)

### DIFF
--- a/modules/ROOT/pages/extending-neo4j/procedures.adoc
+++ b/modules/ROOT/pages/extending-neo4j/procedures.adoc
@@ -56,8 +56,7 @@ These can be used to write integration tests for procedures.
 First, decide what the procedure should do, then write a test that proves that it does it right.
 Finally, write a procedure that passes the test.
 
-Below is a template for testing a procedure that accesses Neo4j's full-text indexes from Cypher.
-
+.An example using JUnit 5 for testing a procedure that returns relationship types found in the graph.
 [source, java]
 ----
 package example;
@@ -108,6 +107,11 @@ public class ManualFullTextIndexTest
 }
 ----
 
+[NOTE]
+====
+The previous example uses JUnit 5, which requires the use of `org.neo4j.harness.junit.extension.Neo4jExtension`.
+If you want to use JUnit 4 with Neo4j 4.x or 5, use `org.neo4j.harness.junit.rule.Neo4jRule` instead.
+====
 
 == Define a procedure
 


### PR DESCRIPTION
adding information about the version of junit used in the example and note with instructions for users who want to keep using a previous version

update after review

removing incorrect extra lines

adding the information that this can also be applied to neo4j 5 instead of just 4

Update modules/ROOT/pages/extending-neo4j/procedures.adoc

Cherry-picked from https://github.com/neo4j/docs-java-reference/pull/103