### PR TITLE
Update project-setup.adoc

### DIFF
--- a/modules/ROOT/pages/extending-neo4j/project-setup.adoc
+++ b/modules/ROOT/pages/extending-neo4j/project-setup.adoc
@@ -149,7 +149,7 @@ Include this dependency to build against the Neo4j-provided API:
 <dependency>
    <groupId>com.neo4j</groupId>
    <artifactId>neo4j-dbms-api</artifactId>
-   <version>${project.version}</version>
+   <version>${neo4j.version}</version>
    <scope>compile</scope>
 </dependency>
 ----


### PR DESCRIPTION
Minor update. I _think_ the maven snippet to include a dependency on the Neo4j API should use neo4j.version in place of project.version. 

In parallel, I'm creating a test project to verify unless anyone who is watching can independently verify and accept this PR.