### PR TITLE
Fixing link to github

### DIFF
--- a/modules/ROOT/pages/java-embedded/terminate.adoc
+++ b/modules/ROOT/pages/java-embedded/terminate.adoc
@@ -9,7 +9,7 @@ You can terminate (abort) a long-running transaction from another thread.
 [TIP]
 ====
 The source code for the examples can befound at:
-https://github.com/neo4j/neo4j-documentation/blob/{neo4j-version}/embedded-examples/src/main/java/org/neo4j/examples/TerminateTransactions.java[TerminateTransactions.java^]
+https://github.com/neo4j/neo4j-documentation/blob/5.0/embedded-examples/src/main/java/org/neo4j/examples/TerminateTransactions.java[TerminateTransactions.java^]
 ====
 
 First, start the database server:


### PR DESCRIPTION
As reported on SEMRush.

I think `{neo4j-version}` is causing a conflict here, but adding "5.0" manually solves the issue. Previous branches are working correctly, so this only needs to be cherry-picked forward. 