### PR TITLE
Update setup.adoc (#222)

### DIFF
--- a/modules/ROOT/pages/java-embedded/setup.adoc
+++ b/modules/ROOT/pages/java-embedded/setup.adoc
@@ -102,7 +102,7 @@ repositories {
    mavenCentral()
 }
 dependencies {
-   compile "org.neo4j:neo4j:$\{neo4jVersion}"
+   implementation "org.neo4j:neo4j:$\{neo4jVersion}"
 }
 ----
 


### PR DESCRIPTION
gradle "compile" deprecated in version 7.x - replaced by "implementation." Correcting.
Cherry-picked from #222 