### PR TITLE
Introduce `DatabaseSeedProvider`

### DIFF
--- a/modules/ROOT/pages/extending-neo4j/project-setup.adoc
+++ b/modules/ROOT/pages/extending-neo4j/project-setup.adoc
@@ -159,7 +159,7 @@ Include this dependency to build against the Neo4j-provided API:
 [role=label--new-5.26]
 ==== `DatabaseSeedProvider`
 
-The `DatabaseSeedProvider` was introduced in 5.26 in favour of `SeedProvider` which is now deprecated.
+In Neo4j 5.26, the `DatabaseSeedProvider` was introduced to replace the now-deprecated `SeedProvider`.
 
 [source, java]
 ----

--- a/modules/ROOT/pages/extending-neo4j/project-setup.adoc
+++ b/modules/ROOT/pages/extending-neo4j/project-setup.adoc
@@ -206,7 +206,7 @@ For example, `file`, `http`, `https` etc.
 
 The stream method should implement a scheme-specific way to obtain an input stream for the backup or dump.
 
-Implementation specific seed configuration can be passed through from options specified in the `CREATE DATABASE` command using `seedConfig`.
+Implementation-specific seed configuration can be passed through from options specified in the `CREATE DATABASE` command using `seedConfig`.
 
 [role=label--deprecated-5.26]
 ==== `SeedProvider`

--- a/modules/ROOT/pages/extending-neo4j/project-setup.adoc
+++ b/modules/ROOT/pages/extending-neo4j/project-setup.adoc
@@ -198,7 +198,10 @@ public class CustomDatabaseSeedProvider implements DatabaseSeedProvider {
 ----
 
 To implement the custom database seed provider, you must implement three methods on the top-level `DatabaseSeedProvider` interface.
-One method to match the URIs it can manage, one to stream backups or dumps from the given URI, and one to inject dependencies in the provider.
+* A method to match the URIs that the provider can manage.
+* A method to stream backups or dumps from a specified URI.
+* A method to inject dependencies in the provider.
+
 Additionally, you must implement a method on the nested `Dependencies` interface to resolve any dependencies required by your seed provider implementation.
 
 Typically, the match method uses the URI scheme (the part specified before the first colon) to determine whether it can support the given URI or not.

--- a/modules/ROOT/pages/extending-neo4j/project-setup.adoc
+++ b/modules/ROOT/pages/extending-neo4j/project-setup.adoc
@@ -156,6 +156,59 @@ Include this dependency to build against the Neo4j-provided API:
 
 === Implement Java class
 
+==== `DatabaseSeedProvider` label:new[Introduced in 5.26]
+
+The `DatabaseSeedProvider` was introduced in 5.26 in favour of `SeedProvider` which is now deprecated.
+
+[source, java]
+----
+import com.neo4j.dbms.seeding.DatabaseSeedProvider;
+
+public class CustomDatabaseSeedProvider implements DatabaseSeedProvider {
+
+  @Override
+	public boolean matches(String uri) {
+   		// Return true if uri is supported by this
+      // provider.
+  }
+
+  @Override
+  public InputStream stream(
+          String uri,
+          Map<String, Object> options) throws IOException {
+          // This method should obtain an input stream in an
+          // implementation specific way.
+  }
+
+  @Override
+  public void inject(Dependencies dependencies) {
+      // This method should provide implementation 
+      // specific dependencies to the provider.
+  }
+
+  public static class CustomDependencies implements Dependencies {
+        @Override
+        public <T> T resolveDependency(Class<T> type) {
+            // This method should resolve dependencies 
+            // required by the provider.
+        }
+    }
+}
+----
+
+To implement the custom database seed provider, you must implement three methods on the top-level `DatabaseSeedProvider` interface.
+One method to match the URIs it can manage, one to stream backups or dumps from the given URI, and one to inject dependencies in the provider.
+Additionally you must implement one method on the nested `Dependencies` interface, to resolve any dependencies required by your seed provider implementation.
+
+Typically, the match method uses the URI scheme (the part specified before the first colon) to determine whether it can support the given URI or not.
+For example, `file`, `http`, `https` etc.
+
+The stream method should implement a scheme-specific way to obtain an input stream for the backup or dump.
+
+Implementation specific seed configuration can be passed through from options specified in the `CREATE DATABASE` command using `seedConfig`.
+
+==== `SeedProvider` label:deprecated[Deprecated in 5.26]
+
 [source, java]
 ----
 import com.neo4j.dbms.seeding.ParsedSeedProviderConfig;

--- a/modules/ROOT/pages/extending-neo4j/project-setup.adoc
+++ b/modules/ROOT/pages/extending-neo4j/project-setup.adoc
@@ -199,7 +199,7 @@ public class CustomDatabaseSeedProvider implements DatabaseSeedProvider {
 
 To implement the custom database seed provider, you must implement three methods on the top-level `DatabaseSeedProvider` interface.
 One method to match the URIs it can manage, one to stream backups or dumps from the given URI, and one to inject dependencies in the provider.
-Additionally you must implement one method on the nested `Dependencies` interface, to resolve any dependencies required by your seed provider implementation.
+Additionally, you must implement a method on the nested `Dependencies` interface to resolve any dependencies required by your seed provider implementation.
 
 Typically, the match method uses the URI scheme (the part specified before the first colon) to determine whether it can support the given URI or not.
 For example, `file`, `http`, `https` etc.

--- a/modules/ROOT/pages/extending-neo4j/project-setup.adoc
+++ b/modules/ROOT/pages/extending-neo4j/project-setup.adoc
@@ -208,7 +208,8 @@ The stream method should implement a scheme-specific way to obtain an input stre
 
 Implementation specific seed configuration can be passed through from options specified in the `CREATE DATABASE` command using `seedConfig`.
 
-==== `SeedProvider` label:deprecated[Deprecated in 5.26]
+[role=label--deprecated-5.26]
+==== `SeedProvider`
 
 [source, java]
 ----

--- a/modules/ROOT/pages/extending-neo4j/project-setup.adoc
+++ b/modules/ROOT/pages/extending-neo4j/project-setup.adoc
@@ -156,7 +156,8 @@ Include this dependency to build against the Neo4j-provided API:
 
 === Implement Java class
 
-==== `DatabaseSeedProvider` label:new[Introduced in 5.26]
+[role=label--new-5.26]
+==== `DatabaseSeedProvider`
 
 The `DatabaseSeedProvider` was introduced in 5.26 in favour of `SeedProvider` which is now deprecated.
 

--- a/modules/ROOT/pages/extending-neo4j/project-setup.adoc
+++ b/modules/ROOT/pages/extending-neo4j/project-setup.adoc
@@ -197,7 +197,8 @@ public class CustomDatabaseSeedProvider implements DatabaseSeedProvider {
 }
 ----
 
-To implement the custom database seed provider, you must implement three methods on the top-level `DatabaseSeedProvider` interface.
+To implement the custom database seed provider, you must define three methods on the top-level `DatabaseSeedProvider` interface:
+
 * A method to match the URIs that the provider can manage.
 * A method to stream backups or dumps from a specified URI.
 * A method to inject dependencies in the provider.


### PR DESCRIPTION
In 5.26 `SeedProvider` was deprecated in favour of `DatabaseSeedProvider`. In 5 LTS `SeedProvider` and `DatabaseSeedProvider` will co-exist. This PR adds `DatabaseSeedProvider` to the documentation with the relevant deprecated/introduction labels. 