### PR TITLE
use display_version to show 5.26

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,7 @@
 name: java-reference
 title: Java Reference
-version: '5.26'
+version: '5'
+display_version: '5.26'
 lts: true
 start_page: ROOT:index.adoc
 nav:


### PR DESCRIPTION
We want to keep the /5/ url for the 5.26 LTS release, while displaying the `major.minor` version number.

This PR achieves that.