### PR TITLE
Replace `page-version` with `current` in links (#260)

### DIFF
--- a/modules/ROOT/pages/extending-neo4j/customized-code.adoc
+++ b/modules/ROOT/pages/extending-neo4j/customized-code.adoc
@@ -53,9 +53,9 @@ In addition, procedures can perform write operations on the database.
 
 Neo4j also comes bundled with a number of _built-in_ procedures and functions.
 
-The available built-in procedures vary depending on edition and mode, as described in link:{neo4j-docs-base-uri}/operations-manual/{page-version}/reference/procedures[Operations Manual -> Procedures].
+The available built-in procedures vary depending on edition and mode, as described in link:{neo4j-docs-base-uri}/operations-manual/{page-version}/procedures[Operations Manual -> Procedures].
 Running `SHOW PROCEDURES` displays the full list of procedures available in your Neo4j DBMS, including user-defined procedures.
 
-The built-in functions are described in link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/functions[Cypher Manual -> Functions].
+The built-in functions are described in link:{neo4j-docs-base-uri}/cypher-manual/current/functions[Cypher Manual -> Functions].
 Running `SHOW FUNCTIONS` displays the full list of all the functions available in your Neo4j DBMS, including user-defined functions.
 

--- a/modules/ROOT/pages/extending-neo4j/procedures.adoc
+++ b/modules/ROOT/pages/extending-neo4j/procedures.adoc
@@ -28,7 +28,7 @@ CALL org.neo4j.examples.findDenseNodes(1000)
 
 `CALL` may be the only clause within a Cypher statement or may be combined with other clauses.
 Arguments can be supplied directly within the query or taken from the associated parameter set.
-For full details, see the documentation in link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/call[Cypher Manual -> `CALL` procedure].
+For full details, see the documentation in link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/call[Cypher Manual -> `CALL` procedure].
 
 
 [[user-defined-procedures]]

--- a/modules/ROOT/pages/extending-neo4j/unmanaged-extensions.adoc
+++ b/modules/ROOT/pages/extending-neo4j/unmanaged-extensions.adoc
@@ -102,7 +102,7 @@ When writing unmanaged extensions, you have greater control over the amount of m
 If you keep too much state around, it can lead to more frequent full Garbage Collection and subsequent unresponsiveness by the Neo4j server.
 
 A common way that state can increase, is the creation of JSON objects to represent the result of a query, which is then sent back to your application.
-Neo4j's Transactional Cypher HTTP endpoint (see link:{neo4j-docs-base-uri}/http-api/{page-version}/actions[HTTP API Docs -> transactional Cypher endpoint]) streams responses back to the client.
+Neo4j's HTTP endpoint (see link:{neo4j-docs-base-uri}/http-api/current/transactions[HTTP API Docs -> Run transactions]) streams responses back to the client.
 For example, the following unmanaged extension streams an array of a person's colleagues:
 
 //https://github.com/neo4j/neo4j-documentation/blob/dev/server-examples/src/main/java/org/neo4j/examples/server/unmanaged/ColleaguesResource.java

--- a/modules/ROOT/pages/extending-neo4j/values-and-types.adoc
+++ b/modules/ROOT/pages/extending-neo4j/values-and-types.adoc
@@ -6,7 +6,7 @@
 [[extending-neo4j-procedures-and-functions-values-and-types]]
 = Values and types
 
-The _input_ and _output_ to and from a procedure or a function must be one of the supported types, as described in link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/values-and-types/[Cypher Manual -> Values and types].
+The _input_ and _output_ to and from a procedure or a function must be one of the supported types, as described in link:{neo4j-docs-base-uri}/cypher-manual/current/values-and-types/[Cypher Manual -> Values and types].
 
 Composite types are supported via:
 

--- a/modules/ROOT/pages/java-embedded/cypher-java.adoc
+++ b/modules/ROOT/pages/java-embedded/cypher-java.adoc
@@ -4,7 +4,7 @@
 [[cypher-java]]
 = Cypher queries
 
-In Java, you can use the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/[Cypher query language] as per the example below.
+In Java, you can use the link:{neo4j-docs-base-uri}/cypher-manual/current/[Cypher query language] as per the example below.
 
 [TIP]
 ====
@@ -118,5 +118,5 @@ You should instead use only one and if you need the facilities of the other meth
 
 For more information on the Java interface to Cypher, see the link:{neo4j-javadocs-base-uri}/index.html[Neo4j Javadocs^].
 
-For more information and examples for Cypher, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/[Neo4j Cypher Manual].
+For more information and examples for Cypher, see link:{neo4j-docs-base-uri}/cypher-manual/current/[Neo4j Cypher Manual].
 

--- a/modules/ROOT/pages/java-embedded/indexes.adoc
+++ b/modules/ROOT/pages/java-embedded/indexes.adoc
@@ -4,10 +4,10 @@
 [[java-embedded-new-index]]
 = Using indexes
 
-It is possible to create and use all the index types described in link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes-for-search-performance[Cypher Manual -> Indexes].
+It is possible to create and use all the index types described in link:{neo4j-docs-base-uri}/cypher-manual/current/indexes-for-search-performance[Cypher Manual -> Indexes].
 
 This section demonstrates how to work with indexes with an example of a user database.
-For information about how to create an index on all `User` nodes that have a `username` property, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes-for-search-performance#administration-indexes-create-a-single-property-index-for-nodes[Cypher Manual -> Create a single-property index for nodes].
+For information about how to create an index on all `User` nodes that have a `username` property, see link:{neo4j-docs-base-uri}/cypher-manual/current/indexes-for-search-performance#administration-indexes-create-a-single-property-index-for-nodes[Cypher Manual -> Create a single-property index for nodes].
 
 [TIP]
 ====

--- a/modules/ROOT/pages/java-embedded/property-values.adoc
+++ b/modules/ROOT/pages/java-embedded/property-values.adoc
@@ -54,6 +54,6 @@ If these objects are returned from procedures, the original types cannot be recr
 [NOTE]
 ====
 Strings that contain special characters can have inconsistent or non-deterministic ordering in Neo4j.
-For details, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/syntax/values#property-types-sip-note[Cypher Manual -> Sorting of special characters].
+For details, see link:{neo4j-docs-base-uri}/cypher-manual/current/syntax/values#property-types-sip-note[Cypher Manual -> Sorting of special characters].
 ====
 

--- a/modules/ROOT/pages/java-embedded/query-parameters.adoc
+++ b/modules/ROOT/pages/java-embedded/query-parameters.adoc
@@ -6,7 +6,7 @@
 
 The following examples illustrate how to use parameters when executing Cypher queries from Java.
 
-For more information on parameters, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/[Neo4j Cypher Manual].
+For more information on parameters, see the link:{neo4j-docs-base-uri}/cypher-manual/current/[Neo4j Cypher Manual].
 
 
 //https://github.com/neo4j/neo4j-documentation/blob/dev/cypher/cypher-docs/src/test/java/org/neo4j/cypher/example/JavaExecutionEngineDocTest.java

--- a/modules/ROOT/pages/java-embedded/unique-nodes.adoc
+++ b/modules/ROOT/pages/java-embedded/unique-nodes.adoc
@@ -82,5 +82,5 @@ You might also be tempted to use Java synchronization for pessimistic locking, b
 By mixing locks in Neo4j and the Java runtime, it is possible to produce deadlocks that are not detectable by Neo4j.
 As long as all locking is done by Neo4j, all deadlocks will be detected and avoided.
 
-For more information on locks and deadlocks, see link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-internals/locks-deadlocks.adoc#_locks[Operations Manual -> Locks and deadlocks^].
+For more information on locks and deadlocks, see link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-internals/concurrent-data-access/#_locks[Operations Manual -> Locks and deadlocks^].
 

--- a/modules/ROOT/pages/transaction-management.adoc
+++ b/modules/ROOT/pages/transaction-management.adoc
@@ -31,7 +31,7 @@ The interaction cycle of working with transactions follows the steps:
 [NOTE]
 ====
 It is crucial to finish each transaction because the locks or memory acquired by a transaction are only released upon completion.
-For more information on locks and deadlocks, see link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-internals/locks-deadlocks[Operations Manual -> Locks and deadlocks^].
+For more information on locks and deadlocks, see link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-internals/concurrent-data-access/#_locks[Operations Manual -> Locks and deadlocks^].
 ====
 
 The idiomatic use of transactions in Neo4j is to use a `try-with-resources` statement and declare `transaction` as one of the resources.


### PR DESCRIPTION
* Replace `page-version` with `current` in links

* Put back `page-version` for the Ops manual and fix links on locks/deadlocks

* Update modules/ROOT/pages/java-embedded/unique-nodes.adoc

* Update modules/ROOT/pages/extending-neo4j/unmanaged-extensions.adoc