### PR TITLE
Fix use of non-public method

### DIFF
--- a/modules/ROOT/pages/traversal-framework/traversal-framework-java-api.adoc
+++ b/modules/ROOT/pages/traversal-framework/traversal-framework-java-api.adoc
@@ -381,6 +381,8 @@ class MaxWeightPathExpander implements PathExpander<Double>
 }
 ----
 
+`ResourceIterable.of` is available starting from Neo4j 2026.03.
+
 Here is an example of how to use the custom `PathExpander` and set the initial state:
 
 [source, java, role="nocopy"]

--- a/modules/ROOT/pages/traversal-framework/traversal-framework-java-api.adoc
+++ b/modules/ROOT/pages/traversal-framework/traversal-framework-java-api.adoc
@@ -370,7 +370,7 @@ class MaxWeightPathExpander implements PathExpander<Double>
                 filtered.add(relationship);
             }
         }
-        return Iterables.asResourceIterable(filtered);
+        return ResourceIterable.of(filtered);
     }
 
     @Override


### PR DESCRIPTION
The method `Iterables.asResourceIterable` called in the example at the end of the page is not part of the public API as lamented e.g. [here](https://community.neo4j.com/t/traversal-framework-working-with-resourceiterables/60963). We added an equivalent to the public API. This PR adjusts the example accordingly.