### PR TITLE
DOCOPS-176 Add page-tabs attributes to publish playbook

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -29,6 +29,9 @@ asciidoc:
   - "@neo4j-antora/antora-listing-roles"
   - "@neo4j-antora/antora-table-footnotes"
   attributes:
+    page-tabs: reference@
+    page-tabs-index: 20
+    page-tabs-group: dbms
     page-theme: docs
     page-type: Docs
     page-search-type: Docs


### PR DESCRIPTION
Adds `page-tabs`, `page-tabs-index` and `page-tabs-group` to `publish.yml`:

```yaml
page-tabs: reference@
page-tabs-index: 20
page-tabs-group: dbms
```

Places this docset in the `reference` tab of the aggregated tabbed navigation, at the
position matching its order in the Docs menu on neo4j.com/docs.

`page-tabs-group` groups this docset with the other DBMS manuals so that every
published version (4.4, 5.x and HEAD) is emitted in the tab navigation and the UI can match it by
version, rather than only the latest version being included.

`page-tabs` is soft-set with a trailing `@` so it can be overridden.
